### PR TITLE
Add Playwright test script for Myntra navigation

### DIFF
--- a/tests/playwright-test.ts
+++ b/tests/playwright-test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to Myntra and verify Men T-Shirts', async ({ page }) => {
+  // Navigate to Myntra website
+  await page.goto('https://www.myntra.com/');
+
+  // Select "Men" from the header menu
+  await page.click('a[href="/shop/men"]');
+
+  // Click the "T-Shirts" link
+  await page.click('a[href="/men-tshirts"]');
+
+  // Verify that the "Men T-Shirts" text is visible on the page
+  const menTShirtsText = await page.locator('text=Men T-Shirts');
+  await expect(menTShirtsText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test script that navigates to the Myntra website, selects 'Men' from the header menu, clicks the 'T-Shirts' link, and verifies that the 'Men T-Shirts' text is visible on the page.